### PR TITLE
Fix a concurrency issue introduced by mDb.close()

### DIFF
--- a/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
+++ b/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
@@ -22,8 +22,11 @@ import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -255,6 +258,50 @@ public class WellSqlTest {
         SuperHero fluxC = WellSql.select(SuperHero.class).getAsModel().get(0);
         assertEquals(Long.MAX_VALUE, fluxC.getLongField());
         assertEquals(Long.MAX_VALUE, fluxC.getLongerField().longValue());
+    }
+
+    @Test
+    public void checkConcurrentInserts() throws InterruptedException {
+        int N = 100;
+        final CountDownLatch countDownLatch = new CountDownLatch(N);
+        for (int i = 0; i < N; i++) {
+            final String name = "FluxC" + String.valueOf(i);
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    WellSql.insert(new SuperHero(name, 1)).execute();
+                    // Random select to probe for a crash
+                    WellSql.select(SuperHero.class).getAsCursor().getCount();
+                    countDownLatch.countDown();
+                }
+            }).start();
+        }
+        assertNotEquals(false, countDownLatch.await(30, TimeUnit.SECONDS));
+        int heroesCount = WellSql.select(SuperHero.class).getAsCursor().getCount();
+        assertEquals(N, heroesCount);
+    }
+
+    @Test
+    public void checkConcurrentSelects() throws InterruptedException {
+        int N = 100;
+        final CountDownLatch countDownLatch = new CountDownLatch(N);
+        for (int i = 0; i < N; i++) {
+            String name = "FluxC" + String.valueOf(i);
+            WellSql.insert(new SuperHero(name, 1)).execute();
+        }
+        for (int i = 0; i < N; i++) {
+            final String name = "FluxC" + String.valueOf(i);
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    int heroCount = WellSql.select(SuperHero.class).where().equals(SuperHeroTable.NAME, name).endWhere()
+                                .getAsCursor().getCount();
+                    assertEquals(1, heroCount);
+                    countDownLatch.countDown();
+                }
+            }).start();
+        }
+        assertNotEquals(false, countDownLatch.await(30, TimeUnit.SECONDS));
     }
 
     private List<SuperHero> getHeroes() {

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/DeleteQuery.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/DeleteQuery.java
@@ -30,40 +30,24 @@ public class DeleteQuery<T extends Identifiable> implements ConditionClauseConsu
 
     public int whereId(List<T> items) {
         int rowsAffected = 0;
-        try {
-            String[] arg = new String[1];
-            for (T item : items) {
-                arg[0] = String.valueOf(item.getId());
-                rowsAffected += mDb.delete(mTableName, WHERE_ID, arg);
-            }
-        } finally {
-            mDb.close();
+        String[] arg = new String[1];
+        for (T item : items) {
+            arg[0] = String.valueOf(item.getId());
+            rowsAffected += mDb.delete(mTableName, WHERE_ID, arg);
         }
         return rowsAffected;
     }
 
     public int whereId(int id) {
-        try {
-            return mDb.delete(mTableName, WHERE_ID, new String[] { String.valueOf(id) });
-        } finally {
-            mDb.close();
-        }
+        return mDb.delete(mTableName, WHERE_ID, new String[]{String.valueOf(id)});
     }
 
     public int whereId(T item) {
-        try {
-            return mDb.delete(mTableName, WHERE_ID, new String[] { String.valueOf(item.getId()) });
-        } finally {
-            mDb.close();
-        }
+        return mDb.delete(mTableName, WHERE_ID, new String[] { String.valueOf(item.getId()) });
     }
 
     public int execute() {
-        try {
-            return mDb.delete(mTableName, mSelection, mArgs);
-        } finally {
-            mDb.close();
-        }
+        return mDb.delete(mTableName, mSelection, mArgs);
     }
 
     @Override

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/InsertQuery.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/InsertQuery.java
@@ -2,12 +2,10 @@ package com.yarolegovich.wellsql;
 
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
-import android.util.Log;
 
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.TableClass;
 import com.yarolegovich.wellsql.mapper.InsertMapper;
-import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 
 import java.util.List;
 
@@ -70,7 +68,6 @@ public class InsertQuery<T extends Identifiable> {
             if (mAsTransaction) {
                 mDb.endTransaction();
             }
-            mDb.close();
         }
     }
 

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/ResetAutoincrementQuery.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/ResetAutoincrementQuery.java
@@ -19,10 +19,6 @@ public class ResetAutoincrementQuery {
     }
 
     public void reset() {
-        try {
-            mDb.delete(TABLE_NAME, SELECTION, new String[] {mName});
-        } finally {
-            mDb.close();
-        }
+        mDb.delete(TABLE_NAME, SELECTION, new String[]{mName});
     }
 }

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/SelectQuery.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/SelectQuery.java
@@ -11,7 +11,6 @@ import android.text.TextUtils;
 
 import com.yarolegovich.wellsql.core.Identifiable;
 import com.yarolegovich.wellsql.core.TableClass;
-import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 import com.yarolegovich.wellsql.mapper.SelectMapper;
 
 import java.lang.annotation.ElementType;
@@ -127,7 +126,6 @@ public class SelectQuery<T extends Identifiable> implements ConditionClauseConsu
             return result;
         } finally {
             cursor.close();
-            mDb.close();
         }
     }
 
@@ -154,7 +152,6 @@ public class SelectQuery<T extends Identifiable> implements ConditionClauseConsu
             return result;
         } finally {
             cursor.close();
-            mDb.close();
         }
     }
 

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/UpdateQuery.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/UpdateQuery.java
@@ -51,15 +51,11 @@ public class UpdateQuery<T extends Identifiable> implements ConditionClauseConsu
     public int replaceWhereId(List<T> items) {
         mSelection = WHERE_ID;
         int rowsAffected = 0;
-        try {
-            String[] args = new String[1];
-            for (T item : items) {
-                args[0] = String.valueOf(item.getId());
-                ContentValues cv = mMapper.toCv(item);
-                rowsAffected += mDb.update(mTableName, cv, mSelection, args);
-            }
-        } finally {
-            mDb.close();
+        String[] args = new String[1];
+        for (T item : items) {
+            args[0] = String.valueOf(item.getId());
+            ContentValues cv = mMapper.toCv(item);
+            rowsAffected += mDb.update(mTableName, cv, mSelection, args);
         }
         return rowsAffected;
     }
@@ -80,11 +76,7 @@ public class UpdateQuery<T extends Identifiable> implements ConditionClauseConsu
     }
 
     public int execute() {
-        try {
-            return mDb.update(mTableName, mContentValues, mSelection, mSelectionArgs);
-        } finally {
-            mDb.close();
-        }
+        return mDb.update(mTableName, mContentValues, mSelection, mSelectionArgs);
     }
 
     @Override

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/WellCursor.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/WellCursor.java
@@ -5,10 +5,7 @@ import android.database.CursorWrapper;
 import android.database.sqlite.SQLiteDatabase;
 import android.support.annotation.Nullable;
 
-import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 import com.yarolegovich.wellsql.mapper.SelectMapper;
-
-import java.util.Iterator;
 
 /**
  * Created by yarolegovich on 01.12.2015.
@@ -28,7 +25,6 @@ public class WellCursor<T> extends CursorWrapper {
     @Override
     public void close() {
         super.close();
-        mDb.close();
     }
 
     @Nullable

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/WellSql.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/WellSql.java
@@ -89,6 +89,10 @@ public class WellSql extends SQLiteOpenHelper {
         return sInstance.getWritableDatabase();
     }
 
+    public static void closeDb() {
+        sInstance.getReadableDatabase().close();
+    }
+
     public static <T> SQLiteMapper<T> mapperFor(Class<T> token) {
         SQLiteMapper<T> mapper = mDbConfig.getMapper(token);
         if (mapper == null) {


### PR DESCRIPTION
Remove `mDb.close()` calls from the Query classes. In a concurrent environment, one query could close the DB while another is running.

The DB should eventually be closed by the app. That's why a new `WellSql.closeDb()` method was added.

2 new unit test, to test:
1. checkout the tests in 56360e7 - run `./gradlew cAT` and notice the test suite crash.
2. checkout the HEAD of the branch (3241196), that includes the fix and run the test suite again. Check all the tests pass.
