### PR TITLE
Fix multiple ORDER BY in SELECT statements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.novoda:bintray-release:0.3.4'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 05 17:40:23 CEST 2016
+#Fri Sep 09 14:43:45 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
+++ b/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
@@ -140,6 +140,27 @@ public class WellSqlTest {
     }
 
     @Test
+    public void multipleOrderByWorks() {
+        WellSql.insert(getHeroes()).execute();
+
+        SuperHero superHero = new SuperHero("FluxC", 1);
+        superHero.setFoughtVillains(42);
+        WellSql.insert(superHero).execute();
+
+        List<SuperHero> heroes = WellSql.select(SuperHero.class)
+                .where().greaterThenOrEqual(SuperHeroTable.FOUGHT, 12).or()
+                .beginGroup().equals(SuperHeroTable.NAME, "Groot").or()
+                .equals(SuperHeroTable.NAME, "Rocket Raccoon").endGroup().endWhere()
+                .orderBy(SelectQuery.ORDER_DESCENDING, SuperHeroTable.FOUGHT, SuperHeroTable.NAME)
+                .limit(12)
+                .getAsModel();
+
+        assertEquals(5, heroes.size());
+        assertTrue(heroes.get(0).getName().equals("FluxC"));
+        assertTrue(heroes.get(1).getName().equals("Douglas Adams"));
+    }
+
+    @Test
     public void constraintsWork() {
         SuperHero hero = getHeroes().get(0);
         hero.setFoughtVillains(-1);

--- a/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
+++ b/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
@@ -131,7 +131,7 @@ public class WellSqlTest {
                 .where().greaterThenOrEqual(SuperHeroTable.FOUGHT, 12).or()
                 .beginGroup().equals(SuperHeroTable.NAME, "Groot").or()
                 .equals(SuperHeroTable.NAME, "Rocket Raccoon").endGroup().endWhere()
-                .orderBy(SelectQuery.ORDER_DESCENDING, SuperHeroTable.FOUGHT)
+                .orderBy(SuperHeroTable.FOUGHT, SelectQuery.ORDER_DESCENDING)
                 .limit(12)
                 .getAsModel();
 
@@ -151,7 +151,8 @@ public class WellSqlTest {
                 .where().greaterThenOrEqual(SuperHeroTable.FOUGHT, 12).or()
                 .beginGroup().equals(SuperHeroTable.NAME, "Groot").or()
                 .equals(SuperHeroTable.NAME, "Rocket Raccoon").endGroup().endWhere()
-                .orderBy(SelectQuery.ORDER_DESCENDING, SuperHeroTable.FOUGHT, SuperHeroTable.NAME)
+                .orderBy(SuperHeroTable.FOUGHT, SelectQuery.ORDER_DESCENDING)
+                .orderBy(SuperHeroTable.NAME, SelectQuery.ORDER_DESCENDING)
                 .limit(12)
                 .getAsModel();
 

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/SelectQuery.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/SelectQuery.java
@@ -86,8 +86,13 @@ public class SelectQuery<T extends Identifiable> implements ConditionClauseConsu
         return this;
     }
 
-    public SelectQuery<T> orderBy(@Order int order, String ...columns) {
-        mSortOrder = TextUtils.join(", ", columns).concat(order >= 0 ? " ASC" : " DESC");
+    public SelectQuery<T> orderBy(String column, @Order int order) {
+        if (!TextUtils.isEmpty(mSortOrder)) {
+            mSortOrder = mSortOrder.concat(", ").concat(column + (order >= 0 ? " ASC" : " DESC"));
+        } else {
+            mSortOrder = column + (order >= 0 ? " ASC" : " DESC");
+        }
+
         return this;
     }
 


### PR DESCRIPTION
Without this PR, if you pass multiple columns to [`.orderBy()`](https://github.com/wordpress-mobile/wellsql/blob/0803fab532bfb42ebeaf442e0878e4ee6c7fcabf/wellsql/src/main/java/com/yarolegovich/wellsql/SelectQuery.java#L90) in a `SELECT`, it only accepts one order (ASC or DESC), and puts them all together. But, actually, all but the last one will use the default sort order, `ASC`, not the one specified at the end.

So,

``` sql
ORDER BY title, content DESC
```

actually means

``` sql
ORDER BY title ASC, content DESC
```

This PR modifies `orderBy` so that it can be called multiple times, each time specifying the sort order for that column.

To test:
1. Checkout e7d4e35 and run the tests - notice the failing test
2. Checkout the branch HEAD, and run the tests again - the broken test should be fixed

cc @maxme 
