### PR TITLE
Add Jitpack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,23 +10,36 @@ Android API for working with SQLiteDatabase can be characterized as inconvenient
 
 ## Add to your project
 
-In build.gradle for your project add
-```gradle
-buildscript {
-  dependencies {
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-  }
-}
-
-```
-In build.gradle for your module add
+In build.gradle for your module add:
 
 ```gradle
-apply plugin: 'com.neenbedankt.android-apt'
-
 dependencies {
-  compile 'com.yarolegovich:wellsql:1.0.5'
-  apt 'com.yarolegovich:wellsql-processor:1.0.5'
+    compile 'org.wordpress:wellsql:1.2.0'
+    annotationProcessor 'org.wordpress:wellsql-processor:1.2.0'
+}
+```
+
+### Jitpack
+
+You can also use Jitpack:
+
+In build.gradle for your project add:
+
+```gradle
+allprojects {
+    repositories {
+        ...
+        maven { url "https://jitpack.io" }
+    }
+}
+```
+
+In build.gradle for your module add:
+
+```gradle
+dependencies {
+    compile 'com.github.wordpress-mobile.wellsql:wellsql:[commit hash or branch snaphost]'
+    annotationProcessor 'com.github.wordpress-mobile.wellsql:well-processor:[commit hash or branch snaphost]'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.novoda:bintray-release:0.3.4'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
 

--- a/well-annotations/build.gradle
+++ b/well-annotations/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'java'
 apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'com.github.dcendents.android-maven'
+
+group = 'com.github.wordpress-mobile'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/well-processor/build.gradle
+++ b/well-processor/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'java'
 apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'com.github.dcendents.android-maven'
+
+group = 'com.github.wordpress-mobile'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/wellsql/build.gradle
+++ b/wellsql/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'com.github.dcendents.android-maven'
+
+group = 'com.github.wordpress-mobile'
 
 android {
     compileSdkVersion 25


### PR DESCRIPTION
Makes the project available through Jitpack for development/testing (while maintaining the Bintray config for normal releases).

The syntax is:

```gradle
 dependencies {
    compile 'com.github.wordpress-mobile.wellsql:wellsql:add-jitpack-SNAPSHOT'
    kapt 'com.github.wordpress-mobile.wellsql:well-processor:add-jitpack-SNAPSHOT'
 }
```

Also updated the `README` with instructions.

cc @maxme