### PR TITLE
Add COUNT() and SELECT 1 support to SelectQuery

### DIFF
--- a/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
+++ b/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -179,6 +180,28 @@ public class WellSqlTest {
                 .where().equals(SuperHeroTable.FOUGHT, 4).endWhere()
                 .count();
         assertEquals(2, heroesFoughtFour);
+    }
+
+    @Test
+    public void selectExistsWorks() {
+        boolean emptyTableExists = WellSql.select(SuperHero.class).exists();
+
+        assertFalse(emptyTableExists);
+
+        WellSql.insert(getHeroes()).execute();
+        boolean tableWithValuesExists = WellSql.select(SuperHero.class).exists();
+
+        assertTrue(tableWithValuesExists);
+
+        boolean heroesFoughtFourExists = WellSql.select(SuperHero.class)
+                .where().equals(SuperHeroTable.FOUGHT, 4).endWhere()
+                .exists();
+        assertTrue(heroesFoughtFourExists);
+
+        boolean heroesFoughtTooManyExists = WellSql.select(SuperHero.class)
+                .where().equals(SuperHeroTable.FOUGHT, 5555).endWhere()
+                .exists();
+        assertFalse(heroesFoughtTooManyExists);
     }
 
     @Test

--- a/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
+++ b/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
@@ -169,6 +169,19 @@ public class WellSqlTest {
     }
 
     @Test
+    public void selectCountWorks() {
+        WellSql.insert(getHeroes()).execute();
+
+        long totalHeroes = WellSql.select(SuperHero.class).count();
+        assertEquals(getHeroes().size(), totalHeroes);
+
+        long heroesFoughtFour = WellSql.select(SuperHero.class)
+                .where().equals(SuperHeroTable.FOUGHT, 4).endWhere()
+                .count();
+        assertEquals(2, heroesFoughtFour);
+    }
+
+    @Test
     public void constraintsWork() {
         SuperHero hero = getHeroes().get(0);
         hero.setFoughtVillains(-1);

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/SelectQuery.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/SelectQuery.java
@@ -1,6 +1,7 @@
 package com.yarolegovich.wellsql;
 
 import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.os.Bundle;
@@ -166,6 +167,11 @@ public class SelectQuery<T extends Identifiable> implements ConditionClauseConsu
 
     public WellCursor<T> getAsCursor(SelectMapper<T> mapper) {
         return new WellCursor<>(mDb, mapper, execute());
+    }
+
+    public long count() {
+        return DatabaseUtils.queryNumEntries(mDb, WellSql.tableFor(mModel).getTableName(),
+                mSelection, mSelectionArgs);
     }
 
     public void getAsModelAsync(final Callback<List<T>> callback) {

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/SelectQuery.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/SelectQuery.java
@@ -169,6 +169,15 @@ public class SelectQuery<T extends Identifiable> implements ConditionClauseConsu
         return new WellCursor<>(mDb, mapper, execute());
     }
 
+    /**
+     * Returns whether any results exist for the query.
+     * Equivalent to <code>SELECT 1 FROM table</code>.
+     */
+    public boolean exists() {
+        mProjection = new String[]{"1"};
+        return !getAsModel().isEmpty();
+    }
+
     public long count() {
         return DatabaseUtils.queryNumEntries(mDb, WellSql.tableFor(mModel).getTableName(),
                 mSelection, mSelectionArgs);


### PR DESCRIPTION
Adds two new functions to `SelectQuery`:

### count()

Implicitly uses a `COUNT` query to return the number of rows matching the query. This is probably more efficient than `getAsCursor().getCount()`.

### exists()

This one uses a `SELECT 1` query as an inexpensive way to check whether at least 1 result exists for the query. Using this, we can replace:
```java
WellSql.select(Model.class)
    .columns("1")
    .where()....endWhere()
    .getAsCursor().getCount() > 0
```
with
```java
WellSql.select(Model.class)
    .where()....endWhere()
    .exists()
```

### To test

Run the connected Android tests and make sure everything passes.