### PR TITLE
Update README with current Gradle dependency syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ In build.gradle for your module add:
 
 ```gradle
 dependencies {
-    compile 'org.wordpress:wellsql:1.2.0'
+    api 'org.wordpress:wellsql:1.2.0'
+    // Use kapt instead of annotationProcessor if you're using Kotlin
     annotationProcessor 'org.wordpress:wellsql-processor:1.2.0'
 }
 ```
@@ -38,7 +39,8 @@ In build.gradle for your module add:
 
 ```gradle
 dependencies {
-    compile 'com.github.wordpress-mobile.wellsql:wellsql:[commit hash or branch snaphost]'
+    api 'com.github.wordpress-mobile.wellsql:wellsql:[commit hash or branch snaphost]'
+    // Use kapt instead of annotationProcessor if you're using Kotlin
     annotationProcessor 'com.github.wordpress-mobile.wellsql:well-processor:[commit hash or branch snaphost]'
 }
 ```


### PR DESCRIPTION
Updates the README to replace `compile` uses with `api` in the Gradle build examples, and adds a note about `kapt`.