### PR TITLE
Updates Bintray and readme versions to 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ In build.gradle for your module add:
 
 ```gradle
 dependencies {
-    api 'org.wordpress:wellsql:1.2.0'
+    api 'org.wordpress:wellsql:1.5.0'
     // Use kapt instead of annotationProcessor if you're using Kotlin
-    annotationProcessor 'org.wordpress:wellsql-processor:1.2.0'
+    annotationProcessor 'org.wordpress:wellsql-processor:1.5.0'
 }
 ```
 
@@ -30,7 +30,7 @@ In build.gradle for your project add:
 allprojects {
     repositories {
         ...
-        maven { url "https://jitpack.io" }
+        maven { url "https://www.jitpack.io" }
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
     groupId = 'org.wordpress'
     uploadName = 'wellsql'
     desc = 'Library that simplifies work with SQLite in Android'
-    publishVersion = '1.4.0'
+    publishVersion = '1.5.0'
     licences = ['MIT']
     website = 'https://github.com/wordpress-mobile/wellsql'
     dryRun = 'false'


### PR DESCRIPTION
This PR updates the Bintray version to `1.5.0` and reflects that in the README. Once we merge this PR, we can tag the `1.5.0` version and then upload it to Bintray. @aforcier Do you mind doing this for me? I think I need some credentials for it, but I couldn't find where those credentials are. (or maybe I don't, I have never uploaded a build to Bintray 😬 )