### PR TITLE
Update Bintray release plugin to 0.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
-        classpath 'com.novoda:bintray-release:0.8.1'
+        classpath 'com.novoda:bintray-release:0.9.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }


### PR DESCRIPTION
Updated the Bintray release plugin version to `0.9.1`, which [added support for projects running Gradle 5.2+](https://github.com/novoda/bintray-release/releases/tag/0.9.1).

The recently published wellsql `1.5.0` version was done using this configuration. No new release cut is necessary.